### PR TITLE
Add automated tests for Odoo connector and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ The HTTP server also exposes a `GET /health` endpoint that can be used for readi
 are streamed back to the client through `tools/stream` notifications followed by a terminal JSON-RPC response when the
 execution completes.
 
+### Running Tests
+
+This project relies on Node's built-in test runner together with `ts-node` for TypeScript support. To execute the full unit test
+suite, run:
+
+```bash
+npm test
+```
+
+The command discovers all `*.test.ts` files under the `tests/` directory and executes them. Include `npm test` as part of your
+CI pipeline to ensure the Odoo connector, masking logic, and confirmation workflows remain covered by automated regression
+tests.
+
 ## 🧰 Implemented Tools
 
 The following MCP tools are available:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "find tests -name '*.test.ts' -print0 | xargs -0 env TS_NODE_TRANSPILE_ONLY=1 node --require ts-node/register --test"
   },
   "keywords": [
     "mcp",

--- a/src/odoo-connector.ts
+++ b/src/odoo-connector.ts
@@ -3,7 +3,7 @@ import { loadEnv } from './env-loader';
 
 loadEnv();
 
-interface OdooConnectionConfig {
+export interface OdooConnectionConfig {
   baseUrl: string;
   db: string;
   username: string;
@@ -35,7 +35,7 @@ export interface OdooTransport {
   getUid(): number | null;
 }
 
-class JsonRpcTransport implements OdooTransport {
+export class JsonRpcTransport implements OdooTransport {
   private readonly config: OdooConnectionConfig;
   private readonly baseUrl: string;
   private readonly timeout = 15000;
@@ -126,7 +126,7 @@ class JsonRpcTransport implements OdooTransport {
   }
 }
 
-function loadConfigFromEnv(): OdooConnectionConfig {
+export function loadConfigFromEnv(): OdooConnectionConfig {
   const baseUrl = process.env.ODOO_URL;
   const db = process.env.ODOO_DB;
   const username = process.env.ODOO_USERNAME;
@@ -139,7 +139,7 @@ function loadConfigFromEnv(): OdooConnectionConfig {
   return { baseUrl, db, username, apiKey };
 }
 
-class OdooConnector {
+export class OdooConnector {
   private readonly transport: OdooTransport;
   private uid: number | null = null;
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -269,6 +269,26 @@ function assertExecutionMode(mode: string): asserts mode is ExecutionMode {
   }
 }
 
+export const __testables = {
+  assertModelAllowed,
+  assertModelWritable,
+  ensureFieldsAllowed,
+  sanitizeOrder,
+  sanitizeValues,
+  maskString,
+  maskValue,
+  maskRecord,
+  maskRecords,
+  normalizeIds,
+  summarizeAction,
+  resolveActor,
+  formatIso,
+  buildPlanMetadata,
+  buildDryRunMetadata,
+  buildConfirmMetadata,
+  assertExecutionMode,
+};
+
 export const versionTool: Tool = {
   name: 'odoo.version',
   description: 'Returns the version information reported by the connected Odoo server.',

--- a/tests/odoo-connector.test.ts
+++ b/tests/odoo-connector.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { OdooTransport, OdooConnectionConfig } from '../src/odoo-connector';
+import { fn, restoreAllMocks } from './test-helpers';
+
+process.env.ODOO_URL = process.env.ODOO_URL ?? 'https://odoo.test';
+process.env.ODOO_DB = process.env.ODOO_DB ?? 'test-db';
+process.env.ODOO_USERNAME = process.env.ODOO_USERNAME ?? 'tester@example.com';
+process.env.ODOO_API_KEY = process.env.ODOO_API_KEY ?? 'test-key';
+
+const {
+  JsonRpcTransport,
+  OdooConnector,
+  loadConfigFromEnv,
+} = require('../src/odoo-connector') as typeof import('../src/odoo-connector');
+
+describe('JsonRpcTransport error handling', () => {
+  const config: OdooConnectionConfig = {
+    baseUrl: 'https://example.odoo.com',
+    db: 'example-db',
+    username: 'user@example.com',
+    apiKey: 'secret',
+  };
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreAllMocks();
+  });
+
+  it('throws when HTTP response is not ok', async () => {
+    const fetchMock = fn().mockResolvedValue({ ok: false, status: 500 });
+    globalThis.fetch = fetchMock as any;
+    const transport = new JsonRpcTransport(config);
+    await assert.rejects(transport.callCommon('version'), {
+      message: 'Odoo request failed with status 500',
+    });
+    assert.equal(fetchMock.mock.calls.length, 1);
+  });
+
+  it('throws when RPC response contains an error payload', async () => {
+    const fetchMock = fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        jsonrpc: '2.0',
+        id: '1',
+        error: { message: 'Access denied', data: { details: 'nope' } },
+      }),
+    });
+    globalThis.fetch = fetchMock as any;
+    const transport = new JsonRpcTransport(config);
+    await assert.rejects(transport.callCommon('version'), {
+      message: 'Access denied: {"details":"nope"}',
+    });
+  });
+
+  it('throws when RPC response lacks a result', async () => {
+    const fetchMock = fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ jsonrpc: '2.0', id: '1' }),
+    });
+    globalThis.fetch = fetchMock as any;
+    const transport = new JsonRpcTransport(config);
+    await assert.rejects(transport.callCommon('version'), {
+      message: 'No result returned from Odoo.',
+    });
+  });
+
+  it('wraps AbortError rejections with a friendly timeout message', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    const fetchMock = fn().mockRejectedValue(abortError);
+    globalThis.fetch = fetchMock as any;
+    const transport = new JsonRpcTransport(config);
+    await assert.rejects(transport.callCommon('version'), {
+      message: 'The request to Odoo timed out.',
+    });
+  });
+
+  it('returns data when the RPC call succeeds', async () => {
+    const fetchMock = fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ jsonrpc: '2.0', id: '1', result: { server_version: '17.0' } }),
+    });
+    globalThis.fetch = fetchMock as any;
+    const transport = new JsonRpcTransport(config);
+    const result = await transport.callCommon('version');
+    assert.deepStrictEqual(result, { server_version: '17.0' });
+  });
+});
+
+describe('OdooConnector', () => {
+  afterEach(() => {
+    restoreAllMocks();
+  });
+
+  it('requires connect() to be called before executing RPC methods', async () => {
+    const connectMock = fn<any[], Promise<number>>().mockResolvedValue(42);
+    const executeMock = fn<any[], Promise<any>>();
+    const callCommonMock = fn<any[], Promise<any>>();
+    const getUidMock = fn().mockReturnValue(42);
+    const transport: OdooTransport = {
+      connect: connectMock as any,
+      executeKw: executeMock as any,
+      callCommon: callCommonMock as any,
+      getUid: getUidMock as any,
+    };
+    const connector = new OdooConnector(transport);
+    await assert.rejects(connector.execute('res.partner', 'search_read'), {
+      message: 'Not connected to Odoo. Please call connect() first.',
+    });
+    await connector.connect();
+    assert.equal(connectMock.mock.calls.length, 1);
+    executeMock.mockResolvedValue(['ok']);
+    const result = await connector.execute('res.partner', 'search_read');
+    assert.deepStrictEqual(result, ['ok']);
+  });
+
+  it('stores the authenticated uid when connect() succeeds', async () => {
+    const connector = new OdooConnector({
+      connect: async () => 99,
+      executeKw: async () => { throw new Error('not used'); },
+      callCommon: async () => { throw new Error('not used'); },
+      getUid: () => 99,
+    });
+    await connector.connect();
+    assert.equal(connector.getUid(), 99);
+  });
+
+  it('fails authentication when the uid is not a number', async () => {
+    const transport = new JsonRpcTransport({
+      baseUrl: 'https://example.odoo.com',
+      db: 'example-db',
+      username: 'user@example.com',
+      apiKey: 'secret',
+    });
+    const originalFetch = globalThis.fetch;
+    const fetchMock = fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ jsonrpc: '2.0', id: '1', result: 'oops' }),
+    });
+    globalThis.fetch = fetchMock as any;
+    await assert.rejects(transport.connect(), {
+      message: 'Authentication failed. Ensure your credentials and API access are correct.',
+    });
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('loadConfigFromEnv', () => {
+  const keys = ['ODOO_URL', 'ODOO_DB', 'ODOO_USERNAME', 'ODOO_API_KEY'] as const;
+  const originalValues: Record<(typeof keys)[number], string | undefined> = {
+    ODOO_URL: process.env.ODOO_URL,
+    ODOO_DB: process.env.ODOO_DB,
+    ODOO_USERNAME: process.env.ODOO_USERNAME,
+    ODOO_API_KEY: process.env.ODOO_API_KEY,
+  };
+
+  afterEach(() => {
+    for (const key of keys) {
+      if (originalValues[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalValues[key] as string;
+      }
+    }
+  });
+
+  it('throws when any required environment variable is missing', () => {
+    for (const key of keys) {
+      delete process.env[key];
+    }
+    assert.throws(() => loadConfigFromEnv(), {
+      message:
+        'Missing required Odoo configuration. Please set ODOO_URL, ODOO_DB, ODOO_USERNAME, and ODOO_API_KEY in your environment.',
+    });
+  });
+
+  it('returns the connection config when all variables are set', () => {
+    process.env.ODOO_URL = 'https://example.odoo.com';
+    process.env.ODOO_DB = 'example-db';
+    process.env.ODOO_USERNAME = 'user@example.com';
+    process.env.ODOO_API_KEY = 'secret';
+    const config = loadConfigFromEnv();
+    assert.deepStrictEqual(config, {
+      baseUrl: 'https://example.odoo.com',
+      db: 'example-db',
+      username: 'user@example.com',
+      apiKey: 'secret',
+    });
+  });
+});

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1,0 +1,100 @@
+export type AnyFn = (...args: any[]) => any;
+
+export interface MockFunction<TArgs extends any[] = any[], TReturn = any> {
+  (...args: TArgs): TReturn;
+  mock: { calls: TArgs[] };
+  mockImplementation(impl: (...args: TArgs) => TReturn): MockFunction<TArgs, TReturn>;
+  mockReturnValue(value: TReturn): MockFunction<TArgs, TReturn>;
+  mockResolvedValue(value: any): MockFunction<TArgs, any>;
+  mockRejectedValue(error: any): MockFunction<TArgs, any>;
+  mockClear(): void;
+  mockRestore(): void;
+}
+
+interface RegisteredSpy {
+  restore(): void;
+}
+
+class SpyRegistry {
+  private readonly spies = new Set<RegisteredSpy>();
+
+  register(entry: RegisteredSpy): void {
+    this.spies.add(entry);
+  }
+
+  restoreAll(): void {
+    for (const entry of this.spies) {
+      entry.restore();
+    }
+    this.spies.clear();
+  }
+}
+
+const registry = new SpyRegistry();
+
+export function fn<TArgs extends any[] = any[], TReturn = any>(
+  implementation?: (...args: TArgs) => TReturn
+): MockFunction<TArgs, TReturn> {
+  const calls: TArgs[] = [];
+  let impl: ((...args: TArgs) => TReturn) | undefined = implementation;
+
+  const mockFunction = (...args: TArgs) => {
+    calls.push(args);
+    if (impl) {
+      return impl(...args);
+    }
+    return undefined as unknown as TReturn;
+  };
+
+  const typedMock = mockFunction as unknown as MockFunction<TArgs, TReturn>;
+  typedMock.mock = { calls };
+  typedMock.mockImplementation = (nextImpl: (...args: TArgs) => TReturn) => {
+    impl = nextImpl;
+    return typedMock;
+  };
+  typedMock.mockReturnValue = (value: TReturn) => {
+    impl = () => value;
+    return typedMock;
+  };
+  typedMock.mockResolvedValue = (value: any) => {
+    impl = () => Promise.resolve(value) as unknown as TReturn;
+    return typedMock as unknown as MockFunction<TArgs, any>;
+  };
+  typedMock.mockRejectedValue = (error: any) => {
+    impl = () => Promise.reject(error) as unknown as TReturn;
+    return typedMock as unknown as MockFunction<TArgs, any>;
+  };
+  typedMock.mockClear = () => {
+    calls.length = 0;
+  };
+  typedMock.mockRestore = () => {
+    impl = implementation;
+    calls.length = 0;
+  };
+
+  registry.register({ restore: () => typedMock.mockRestore() });
+  return typedMock;
+}
+
+export function spyOn<T extends object, K extends keyof T>(
+  target: T,
+  property: K
+): MockFunction<any, any> {
+  const original = target[property] as unknown as AnyFn;
+  const boundOriginal = typeof original === 'function' ? original.bind(target) : () => original;
+  const spy = fn(boundOriginal);
+
+  (target as any)[property] = spy;
+  registry.register({
+    restore: () => {
+      (target as any)[property] = original;
+      spy.mockRestore();
+    },
+  });
+
+  return spy;
+}
+
+export function restoreAllMocks(): void {
+  registry.restoreAll();
+}

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { ActionStateStore, InMemoryEventStore, type ToolExecutionContext } from '../src/mcp';
+import { fn, spyOn, restoreAllMocks } from './test-helpers';
+
+process.env.ODOO_URL = process.env.ODOO_URL ?? 'https://odoo.test';
+process.env.ODOO_DB = process.env.ODOO_DB ?? 'test-db';
+process.env.ODOO_USERNAME = process.env.ODOO_USERNAME ?? 'tester@example.com';
+process.env.ODOO_API_KEY = process.env.ODOO_API_KEY ?? 'test-key';
+
+const { createTool, __testables } = require('../src/tools') as typeof import('../src/tools');
+const { odooConnector } = require('../src/odoo-connector') as typeof import('../src/odoo-connector');
+
+describe('field sanitization helpers', () => {
+  const { ensureFieldsAllowed, sanitizeValues, sanitizeOrder } = __testables;
+
+  it('falls back to the model whitelist when fields are omitted', () => {
+    const fields = ensureFieldsAllowed('res.partner');
+    assert.ok(fields.length > 0);
+    assert.ok(fields.includes('name'));
+  });
+
+  it('throws when a requested field is not allowed', () => {
+    assert.throws(
+      () => ensureFieldsAllowed('res.partner', ['id', 'forbidden_field']),
+      /Fields not allowed for model res\.partner: forbidden_field/
+    );
+  });
+
+  it('strips disallowed keys from values payloads', () => {
+    const sanitized = sanitizeValues('res.partner', {
+      name: 'Alice',
+      email: 'alice@example.com',
+      sneaky: 'value',
+    });
+    assert.deepStrictEqual(sanitized, { name: 'Alice', email: 'alice@example.com' });
+  });
+
+  it('rejects order clauses that reference non-whitelisted fields', () => {
+    assert.throws(
+      () => sanitizeOrder('res.partner', 'name ASC, forbidden DESC'),
+      /Order clause references disallowed fields: forbidden DESC/
+    );
+    assert.equal(sanitizeOrder('res.partner', 'name ASC, email DESC'), 'name ASC, email DESC');
+  });
+});
+
+describe('PII masking', () => {
+  const { maskRecord, maskString } = __testables;
+
+  it('masks sensitive fields while keeping other data intact', () => {
+    const record = {
+      id: 1,
+      name: 'Alice',
+      email: 'alice@example.com',
+      phone: '1234567890',
+      nested: { city: 'New York', safe: 'ok' },
+    };
+    const masked = maskRecord(record);
+    assert.equal(masked.email, maskString('alice@example.com'));
+    assert.equal(masked.phone, maskString('1234567890'));
+    assert.equal(masked.name, 'Alice');
+    assert.equal(masked.nested.city, maskString('New York'));
+    assert.equal(masked.nested.safe, 'ok');
+  });
+});
+
+describe('create tool confirmation workflow', () => {
+  const { sanitizeValues, maskRecord } = __testables;
+  let context: ToolExecutionContext;
+
+  beforeEach(() => {
+    const eventStore = new InMemoryEventStore();
+    const actionStore = new ActionStateStore(eventStore);
+    context = {
+      sessionId: 'session-1',
+      clientInfo: { name: 'Reviewer' },
+      eventStore,
+      actionStore,
+    };
+    spyOn(odooConnector, 'checkAccessRights').mockResolvedValue(true);
+    spyOn(odooConnector, 'create').mockResolvedValue(123);
+  });
+
+  afterEach(() => {
+    restoreAllMocks();
+  });
+
+  it('requires plan → dry_run → confirm and masks sensitive previews', async () => {
+    const input = {
+      model: 'res.partner',
+      values: { name: 'Alice', email: 'alice@example.com', sneaky: 'ignore me' },
+    };
+
+    const planResult = await createTool.execute({ ...input, mode: 'plan' }, context);
+    assert.equal(planResult.action, 'plan:create');
+    assert.ok(planResult.action_id);
+    assert.deepStrictEqual(planResult.metadata, { requested_by: 'Reviewer' });
+    const expectedValues = sanitizeValues('res.partner', input.values);
+    assert.deepStrictEqual(planResult.payload.values, expectedValues);
+
+    const dryRunResult = await createTool.execute({ ...input, mode: 'dry_run' }, context);
+    assert.equal(dryRunResult.action, 'dry_run:create');
+    assert.equal(dryRunResult.action_id, planResult.action_id);
+    assert.equal(dryRunResult.metadata.approved_by, 'Reviewer');
+    const maskedValues = maskRecord(expectedValues);
+    assert.deepStrictEqual(dryRunResult.payload.values, maskedValues);
+
+    const confirmResult = await createTool.execute(
+      { ...input, mode: 'confirm', action_id: dryRunResult.action_id },
+      context
+    );
+    const createMock = odooConnector.create as unknown as ReturnType<typeof fn>;
+    assert.equal(createMock.mock.calls.length, 1);
+    assert.deepStrictEqual(createMock.mock.calls[0][1], expectedValues);
+    assert.deepStrictEqual(confirmResult.metadata.requested_by, 'Reviewer');
+    assert.equal(confirmResult.metadata.approved_by, 'Reviewer');
+    assert.equal(confirmResult.metadata.confirmed_by, 'Reviewer');
+    assert.equal(confirmResult.approval.approved_by, 'Reviewer');
+    assert.equal(confirmResult.id, 123);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the placeholder npm test script with a Node test runner command and document the workflow
- export connector internals and tool helpers so they can be exercised from tests
- add unit tests with lightweight mocks that cover connector error handling plus tool sanitization, masking, and confirmation flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb63d39d883288e0a4f3f02c8389a