### PR TITLE
Fix Odoo read RPC parameter ordering

### DIFF
--- a/src/odoo-connector.ts
+++ b/src/odoo-connector.ts
@@ -211,8 +211,12 @@ export class OdooConnector {
     return this.execute<T[]>(model, 'search_read', [domain], kwargs);
   }
 
-  public async read<T>(model: string, ids: number[], fields: string[]): Promise<T[]> {
-    return this.execute<T[]>(model, 'read', [ids], { fields });
+  public async read<T>(model: string, ids: number[], fields: string[] = []): Promise<T[]> {
+    const params: any[] = [ids];
+    if (fields.length > 0) {
+      params.push(fields);
+    }
+    return this.execute<T[]>(model, 'read', params);
   }
 
   public async count(model: string, domain: any[]): Promise<number> {

--- a/tests/odoo-connector.test.ts
+++ b/tests/odoo-connector.test.ts
@@ -134,6 +134,28 @@ describe('OdooConnector', () => {
     assert.equal(connector.getUid(), 99);
   });
 
+  it('passes read fields as positional arguments', async () => {
+    const connectMock = fn<any[], Promise<number>>().mockResolvedValue(7);
+    const executeKwMock = fn<any[], Promise<any>>().mockResolvedValue([{ id: 1 }]);
+    const transport: OdooTransport = {
+      connect: connectMock as any,
+      executeKw: executeKwMock as any,
+      callCommon: fn<any[], Promise<any>>() as any,
+      getUid: fn().mockReturnValue(7) as any,
+    };
+    const connector = new OdooConnector(transport);
+    await connector.connect();
+    const result = await connector.read('res.partner', [1], ['name', 'email']);
+    assert.equal(executeKwMock.mock.calls.length, 1);
+    assert.deepStrictEqual(executeKwMock.mock.calls[0], [
+      'res.partner',
+      'read',
+      [[1], ['name', 'email']],
+      {},
+    ]);
+    assert.deepStrictEqual(result, [{ id: 1 }]);
+  });
+
   it('fails authentication when the uid is not a number', async () => {
     const transport = new JsonRpcTransport({
       baseUrl: 'https://example.odoo.com',


### PR DESCRIPTION
## Summary
- ensure `OdooConnector.read` passes field lists as positional RPC arguments
- add regression coverage confirming the updated transport call shape

## Testing
- npm test -- --watch=false *(fails: Cannot find module 'ts-node/register' because dev dependencies cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdda04df988328a7f49b589cfcc294